### PR TITLE
[FEATURE] Updated the design of all Material Alert Dialogs

### DIFF
--- a/emulair-app/src/main/java/com/bigbratan/emulair/fragmentPauseMenuActions/PauseMenuFragment.kt
+++ b/emulair-app/src/main/java/com/bigbratan/emulair/fragmentPauseMenuActions/PauseMenuFragment.kt
@@ -84,7 +84,8 @@ class PauseMenuFragment : PreferenceFragmentCompat() {
     }
 
     private fun handleRestartAction(activity: Activity?, context: Context) {
-        MaterialAlertDialogBuilder(context, R.style.AlertDialog)
+        // MaterialAlertDialogBuilder(context, R.style.AlertDialog)
+        MaterialAlertDialogBuilder(context)
             .setTitle(R.string.popup_title)
             .setMessage(R.string.pause_menu_restart_prompt)
             .setPositiveButton(R.string.button_ok) { _, _ ->
@@ -98,7 +99,8 @@ class PauseMenuFragment : PreferenceFragmentCompat() {
     }
 
     private fun handleQuitAction(activity: Activity?, context: Context) {
-        MaterialAlertDialogBuilder(context, R.style.AlertDialog)
+        // MaterialAlertDialogBuilder(context, R.style.AlertDialog)
+        MaterialAlertDialogBuilder(context)
             .setTitle(R.string.popup_title)
             .setMessage(R.string.pause_menu_quit_prompt)
             .setPositiveButton(R.string.button_ok) { _, _ ->

--- a/emulair-app/src/main/java/com/bigbratan/emulair/fragmentSettings/AdvancedFragment.kt
+++ b/emulair-app/src/main/java/com/bigbratan/emulair/fragmentSettings/AdvancedFragment.kt
@@ -52,7 +52,8 @@ class AdvancedFragment : PreferenceFragmentCompat() {
     }
 
     private fun handleResetSettings() {
-        MaterialAlertDialogBuilder(requireContext(), R.style.AlertDialog)
+        // MaterialAlertDialogBuilder(requireContext(), R.style.AlertDialog)
+        MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.popup_title)
             .setMessage(R.string.advanced_general_reset_popup_description)
             .setPositiveButton(R.string.button_ok) { _, _ ->

--- a/emulair-app/src/main/java/com/bigbratan/emulair/fragmentSettings/GamePadBindingActivity.kt
+++ b/emulair-app/src/main/java/com/bigbratan/emulair/fragmentSettings/GamePadBindingActivity.kt
@@ -22,7 +22,8 @@ class GamePadBindingActivity : RetrogradeActivity() {
         inputBindingUpdater = InputBindingUpdater(inputDeviceManager, intent)
 
         if (savedInstanceState == null) {
-            MaterialAlertDialogBuilder(this, R.style.AlertDialog)
+            // MaterialAlertDialogBuilder(this, R.style.AlertDialog)
+            MaterialAlertDialogBuilder(this)
                 .setTitle(inputBindingUpdater.getTitle(applicationContext))
                 .setMessage(inputBindingUpdater.getMessage(applicationContext))
                 .setOnKeyListener { _, _, event -> handleKeyEvent(event) }

--- a/emulair-app/src/main/java/com/bigbratan/emulair/fragmentSettings/SettingsFragment.kt
+++ b/emulair-app/src/main/java/com/bigbratan/emulair/fragmentSettings/SettingsFragment.kt
@@ -148,7 +148,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun handleResetSettings() {
-        MaterialAlertDialogBuilder(requireContext(), R.style.AlertDialog)
+        // MaterialAlertDialogBuilder(requireContext(), R.style.AlertDialog)
+        MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.popup_title)
             .setMessage(R.string.advanced_general_reset_popup_description)
             .setPositiveButton(R.string.button_ok) { _, _ ->

--- a/emulair-app/src/main/java/com/bigbratan/emulair/ui/CustomListPreference.kt
+++ b/emulair-app/src/main/java/com/bigbratan/emulair/ui/CustomListPreference.kt
@@ -18,7 +18,8 @@ class CustomListPreference : ListPreference {
     constructor(context: Context?) : super(context)
 
     override fun onClick() {
-        val builder = MaterialAlertDialogBuilder(context, R.style.AlertDialog).setSingleChoiceItems(entries, getValueIndex()) { dialog, index ->
+        // val builder = MaterialAlertDialogBuilder(context, R.style.AlertDialog).setSingleChoiceItems(entries, getValueIndex()) { dialog, index ->
+        val builder = MaterialAlertDialogBuilder(context).setSingleChoiceItems(entries, getValueIndex()) { dialog, index ->
             if (callChangeListener(entryValues[index].toString())) {
                 setValueIndex(index)
             }

--- a/emulair-app/src/main/java/com/bigbratan/emulair/ui/CustomMultiListPreference.kt
+++ b/emulair-app/src/main/java/com/bigbratan/emulair/ui/CustomMultiListPreference.kt
@@ -21,7 +21,8 @@ class CustomMultiListPreference : MultiSelectListPreference {
     val checkedItems = BooleanArray(entryValues.size)
 
     override fun onClick() {
-        val builder = MaterialAlertDialogBuilder(context, R.style.AlertDialog).setMultiChoiceItems(
+        // val builder = MaterialAlertDialogBuilder(context, R.style.AlertDialog).setMultiChoiceItems(
+        val builder = MaterialAlertDialogBuilder(context).setMultiChoiceItems(
             entries,
             checkedItems
         ) { dialog, which, isChecked ->

--- a/emulair-app/src/main/java/com/bigbratan/emulair/utils/android/ActivityUtils.kt
+++ b/emulair-app/src/main/java/com/bigbratan/emulair/utils/android/ActivityUtils.kt
@@ -9,7 +9,8 @@ fun Activity.displayErrorDialog(messageId: Int, actionLabelId: Int, action: () -
 }
 
 fun Activity.displayErrorDialog(message: String, actionLabel: String, action: () -> Unit) {
-    MaterialAlertDialogBuilder(this, R.style.AlertDialog)
+    // MaterialAlertDialogBuilder(this, R.style.AlertDialog)
+    MaterialAlertDialogBuilder(this)
         .setMessage(message)
         .setPositiveButton(actionLabel) { _, _ -> action() }
         .setCancelable(false)


### PR DESCRIPTION
They now use the default Material Design 3 styles and animations, no longer relying on a custom theme defined in :emulair-app's material-themes.xml. However, this change may not be compatible with devices running A11 or lower, because I forgot why I created the aforementioned theme (which I now removed) in the first place. Needs checking on a device with A11.